### PR TITLE
PY2: Import getargspec, as only args is used

### DIFF
--- a/nitime/analysis/base.py
+++ b/nitime/analysis/base.py
@@ -1,5 +1,8 @@
 
-from inspect import getfullargspec
+try:
+    from inspect import getfullargspec
+except ImportError:  # PY2
+    from inspect import getargspec as getfullargspec
 
 from nitime import descriptors as desc
 


### PR DESCRIPTION
This fixes the tests locally. I tagged the line with `PY2` for easy purging later.